### PR TITLE
Let us touch submodels and supermodels

### DIFF
--- a/lib/active_record/acts_as/instance_methods.rb
+++ b/lib/active_record/acts_as/instance_methods.rb
@@ -82,7 +82,17 @@ module ActiveRecord
       end
 
       def touch(*args)
-        acting_as.touch(*args) if acting_as.persisted?
+        supermodel_args = []
+        submodel_args = []
+        args.each do |arg|
+          if has_attribute?(arg, true)
+            submodel_args << arg
+          else
+            supermodel_args << arg
+          end
+        end
+        super(*submodel_args) if submodel_args.any?
+        acting_as.touch(*supermodel_args) if acting_as.persisted?
       end
 
       def respond_to?(name, include_private = false, as_original_class = false)

--- a/spec/acts_as_spec.rb
+++ b/spec/acts_as_spec.rb
@@ -226,9 +226,14 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
         pen.touch(:one, :two)
       end
 
-      it "can touch a submodel attribute" do
+      it "can touch a submodel attribute without raising error" do
         pen.save!
         expect { pen.touch(:pressed_datetime) }.to_not raise_error
+      end
+
+      it "can touch a submodel attribute and change attribute" do
+        pen.save
+        expect{ pen.touch(:pressed_datetime) }.to change { pen.pressed_datetime }
       end
 
       it "touches supermodel on save" do

--- a/spec/acts_as_spec.rb
+++ b/spec/acts_as_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
           "pen_collection_id": null,
           "settings": {"global_option":"globalvalue", "option1":"value1"},
           "color": "red",
+          "pressed_datetime": null,
           "created_at": ' + pen.created_at.to_json + ',
           "updated_at": ' + pen.updated_at.to_json + '
         }
@@ -353,6 +354,7 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
         "created_at"        => nil,
         "updated_at"        => nil,
         "color"             => "red",
+        "pressed_datetime"  => nil,
         "pen_collection_id" => nil
       )
     end
@@ -360,7 +362,7 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
 
   describe "#attribute_names" do
     it "returns the attribute names of the supermodel and submodel" do
-      expect(pen.attribute_names).to eq(["id", "color", "pen_collection_id", "name", "price", "store_id", "settings", "created_at", "updated_at"])
+      expect(pen.attribute_names).to eq(["id", "color", "pressed_datetime", "pen_collection_id", "name", "price", "store_id", "settings", "created_at", "updated_at"])
     end
   end
 

--- a/spec/acts_as_spec.rb
+++ b/spec/acts_as_spec.rb
@@ -225,6 +225,11 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
         pen.touch(:one, :two)
       end
 
+      it "can touch a submodel attribute" do
+        pen.save!
+        expect { pen.touch(:pressed_datetime) }.to_not raise_error
+      end
+
       it "touches supermodel on save" do
         pen.save
         pen.reload

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -84,6 +84,7 @@ def initialize_schema
 
     create_table :pens do |t|
       t.string :color
+      t.datetime :pressed_datetime, null: true
       t.integer :pen_collection_id
     end
 


### PR DESCRIPTION
I've seen that in README you suggest that attributes that are updated via time/touch should live on the supermodel, however, our legacy infrastructure has some events that live on the submodel. I was wondering if we could coexist? 

![image](https://68.media.tumblr.com/0ae4a458b02b1705c96dd846493e2aad/tumblr_inline_n3ghj9J3u91qcklud.gif)
