### PR TITLE
 Use has_changes_to_save? instead of saved_changes? on acting_as

### DIFF
--- a/lib/active_record/acts_as/instance_methods.rb
+++ b/lib/active_record/acts_as/instance_methods.rb
@@ -9,6 +9,10 @@ module ActiveRecord
         super || acting_as?(klass)
       end
 
+      def saved_changes?
+        super || acting_as.has_changes_to_save? || (defined?(@_acting_as_changed) ? @_acting_as_changed : false)
+      end
+
       def changed?
         super || acting_as.changed? || (defined?(@_acting_as_changed) ? @_acting_as_changed : false)
       end

--- a/lib/active_record/acts_as/relation.rb
+++ b/lib/active_record/acts_as/relation.rb
@@ -32,7 +32,7 @@ module ActiveRecord
           end
 
           before_save do
-            @_acting_as_changed = ActiveRecord.version.to_s.to_f >= 5.1 ? acting_as.saved_changes? : acting_as.changed?
+            @_acting_as_changed = ActiveRecord.version.to_s.to_f >= 5.1 ? acting_as.has_changes_to_save? : acting_as.changed?
             true
           end
           after_commit do


### PR DESCRIPTION
According to [this comment](https://github.com/rails/rails/pull/25337#issuecomment-225166796), `saved_changes?` checks if the last save changed any attributes, while `has_changes_to_save?` checks if the record has unsaved changes. In this case the latter would be the correct one since the `acting_as` record is not yet saved in the `after_update` callback when checking if the current record needs to be touched.