### PR TITLE
Restore functionality that resolves belongs_to members in child classes when performing queries.

### DIFF
--- a/lib/active_record/acts_as/querying.rb
+++ b/lib/active_record/acts_as/querying.rb
@@ -13,7 +13,8 @@ module ActiveRecord
           opts, acts_as_opts = opts.stringify_keys.partition do |k, v|
             v.is_a?(Hash) ||
             k =~ /\./     ||
-            column_names.include?(k.to_s)
+            column_names.include?(k.to_s) ||
+            attribute_method?(k.to_s)
           end.map(&:to_h)
 
           if acts_as_opts.any?

--- a/spec/acts_as_spec.rb
+++ b/spec/acts_as_spec.rb
@@ -481,6 +481,16 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
       end
     end
 
+    describe 'relational methods' do
+      it "allows relational members in query conditions" do
+        magenta_collection = PenCollection.new
+        magenta_pen = magenta_collection.pens.build(color: "magenta", price: 1.0, name: "magenta")
+        magenta_collection.save!
+
+        expect(Pen.where(pen_collection: magenta_pen.pen_collection).take!).to eq(magenta_pen)
+      end
+    end
+
     describe '.find_by' do
       it 'respects supermodel attributes' do
         expect(Pen.find_by(name: 'red pen')).to   eq(@red_pen)


### PR DESCRIPTION
Fixes https://github.com/krautcomputing/active_record-acts_as/issues/18