### PR TITLE
Add rails default output

### DIFF
--- a/lib/active_record/acts_as/relation.rb
+++ b/lib/active_record/acts_as/relation.rb
@@ -93,7 +93,7 @@ module ActiveRecord
           end
 
           def self.scope(*)
-            callable_by_submodel super
+            super.tap(&method(:callable_by_submodel))
           end
 
           alias_method :specific, name


### PR DESCRIPTION
Since we're overriding rails default `self.scope` method, this commit
captures the output in a variable, and returns it at the end of the
method.
This would allow other gems or programs that rely on the default output
to perform any desired business logic or side effects, by overriding
the `self.scope` method themselves, as they wish
( close issue #22  )