### PR TITLE
Allow scope via actable

### DIFF
--- a/active_record-acts_as.gemspec
+++ b/active_record-acts_as.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Hassan Zamani", "Manuel Meurer"]
   spec.email         = ["hsn.zamani@gmail.com", "manuel@krautcomputing.com"]
   spec.summary       = %q{Simulate multi-table inheritance for activerecord models}
-  spec.description   = %q{Simulate multi-table inheritance for activerecord models using a plymorphic association}
+  spec.description   = %q{Simulate multi-table inheritance for activerecord models using a polymorphic association}
   spec.homepage      = "http://github.com/krautcomputing/active_record-acts_as"
   spec.license       = "MIT"
 

--- a/active_record-acts_as.gemspec
+++ b/active_record-acts_as.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal", "~> 2.1"
   spec.add_development_dependency "guard-rspec", "~> 4.7"
 
-  spec.add_dependency "activesupport", ">= 4.2"
-  spec.add_dependency "activerecord", ">= 4.2"
+  spec.add_dependency "activesupport", ">= 4.2", "< 5.2.2.rc1"
+  spec.add_dependency "activerecord", ">= 4.2", "< 5.2.2.rc1"
 end

--- a/lib/active_record/acts_as/relation.rb
+++ b/lib/active_record/acts_as/relation.rb
@@ -76,10 +76,14 @@ module ActiveRecord
           super || acting_as?(klass)
         end
 
-        def actable(options = {})
+        def actable(scope = nil, **options)
           name = options.delete(:as) || :actable
 
-          reflections = belongs_to(name, options.reverse_merge(validate: false, polymorphic: true, dependent: :destroy, autosave: true, inverse_of: to_s.underscore))
+          reflections = belongs_to(name, scope, options.reverse_merge(validate: false,
+                                                                      polymorphic: true,
+                                                                      dependent: :destroy,
+                                                                      autosave: true,
+                                                                      inverse_of: to_s.underscore))
 
           cattr_reader(:actable_reflection) { reflections.stringify_keys[name.to_s] }
 

--- a/spec/acts_as_spec.rb
+++ b/spec/acts_as_spec.rb
@@ -411,6 +411,28 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
     end
   end
 
+  describe '.actable' do
+    class User < ActiveRecord::Base
+      actable -> { unscope(:where) }
+    end
+
+    class Customer < ActiveRecord::Base
+      default_scope { where('identifier > 1') }
+      acts_as :user
+
+      validates_presence_of :identifier
+    end
+
+    context 'with scope' do
+      it 'unscopes default scope' do
+        customer = Customer.create!(identifier: 1)
+        user = customer.user.reload
+        expect(user).to be_a User
+        expect(user.actable).to eq(customer)
+      end
+    end
+  end
+
   context 'class methods' do
     before(:each) { clear_database }
 

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -91,6 +91,15 @@ end
 
 def initialize_schema
   initialize_database do
+    create_table :users do |t|
+      t.timestamps null: true
+      t.actable
+    end
+
+    create_table :customers do |t|
+      t.integer :identifier
+    end
+
     create_table :pen_collections do |t|
       t.timestamps null: true
     end


### PR DESCRIPTION
This pr allows `scope` to pass through which is currently missing.