### PR TITLE
Add support for `activerecord` 5.2.2

### DIFF
--- a/lib/active_record/acts_as/querying.rb
+++ b/lib/active_record/acts_as/querying.rb
@@ -28,10 +28,8 @@ module ActiveRecord
 
     module ScopeForCreate
       def scope_for_create(attributes = nil)
-        scope = ActiveRecord.version.to_s.to_f >= 5.2 ? super(attributes) : where_values_hash
-        if acting_as?
-          scope.merge!(where_values_hash(acting_as_model.table_name))
-        end
+        scope = respond_to?(:values_for_create) ? values_for_create(attributes) : where_values_hash
+        scope.merge!(where_values_hash(acting_as_model.table_name)) if acting_as?
         scope.merge(create_with_value)
       end
     end


### PR DESCRIPTION
In relation to the changes in `activerecord` version `5.2.2`in using `scope_for_create` (https://github.com/rails/rails/pull/33639/files), we must use the new method `values_for_create` provided.

This will resolves the issue https://github.com/krautcomputing/active_record-acts_as/issues/27.