### PR TITLE
Handle argument delegation for Ruby 3

### DIFF
--- a/lib/active_record/acts_as/instance_methods.rb
+++ b/lib/active_record/acts_as/instance_methods.rb
@@ -117,9 +117,9 @@ module ActiveRecord
         duplicate
       end
 
-      def method_missing(method, *args, &block)
+      def method_missing(method, *args, **kwargs, &block)
         if !self_respond_to?(method) && acting_as.respond_to?(method)
-          acting_as.send(method, *args, &block)
+          acting_as.send(method, *args, **kwargs, &block)
         else
           super
         end


### PR DESCRIPTION
Hi,

I'm trying to get rid of all the warnings I have when I launch Rspec on my project. Like this one:
> ruby/gems/2.7.0/gems/active_record-acts_as-5.0.0/lib/active_record/acts_as/instance_methods.rb:120: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call

I get ride of the warning by explicitly delegate keyword arguments.